### PR TITLE
Fix popupmenu leak

### DIFF
--- a/src/main/java/com/pyamsoft/padlock/app/lock/LockScreenActivity.java
+++ b/src/main/java/com/pyamsoft/padlock/app/lock/LockScreenActivity.java
@@ -29,6 +29,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.preference.PreferenceManager;
+import android.support.v7.widget.ActionMenuView;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -239,8 +240,11 @@ public class LockScreenActivity extends ActivityBase implements LockScreen {
   @Override protected void onPause() {
     super.onPause();
     if (isFinishing() || isChangingConfigurations()) {
-      closeOptionsMenu();
-      closeContextMenu();
+      final View amv = binding.toolbar.getChildAt(1);
+      if (amv instanceof ActionMenuView) {
+        final ActionMenuView actions = (ActionMenuView) amv;
+        actions.dismissPopupMenus();
+      }
     }
   }
 

--- a/src/main/java/com/pyamsoft/padlock/app/lock/LockScreenActivity.java
+++ b/src/main/java/com/pyamsoft/padlock/app/lock/LockScreenActivity.java
@@ -240,11 +240,9 @@ public class LockScreenActivity extends ActivityBase implements LockScreen {
   @Override protected void onPause() {
     super.onPause();
     if (isFinishing() || isChangingConfigurations()) {
-      final View amv = binding.toolbar.getChildAt(1);
-      if (amv instanceof ActionMenuView) {
-        final ActionMenuView actions = (ActionMenuView) amv;
-        actions.dismissPopupMenus();
-      }
+      Timber.d("Even though a leak is reported, this should dismiss the window, and clear the leak");
+      binding.toolbar.getMenu().close();
+      binding.toolbar.dismissPopupMenus();
     }
   }
 

--- a/src/main/java/com/pyamsoft/padlock/app/main/MainActivity.java
+++ b/src/main/java/com/pyamsoft/padlock/app/main/MainActivity.java
@@ -108,8 +108,11 @@ public class MainActivity extends RatingActivity implements MainPresenter.MainVi
   @Override protected void onPause() {
     super.onPause();
     if (isFinishing() || isChangingConfigurations()) {
-      closeOptionsMenu();
-      closeContextMenu();
+      final View amv = binding.toolbar.getChildAt(1);
+      if (amv instanceof ActionMenuView) {
+        final ActionMenuView actions = (ActionMenuView) amv;
+        actions.dismissPopupMenus();
+      }
     }
   }
 
@@ -142,7 +145,7 @@ public class MainActivity extends RatingActivity implements MainPresenter.MainVi
 
   @CheckResult @NonNull public View getSettingsMenuItemView() {
     final View amv = binding.toolbar.getChildAt(1);
-    if (amv != null && amv instanceof ActionMenuView) {
+    if (amv instanceof ActionMenuView) {
       final ActionMenuView actions = (ActionMenuView) amv;
       // Settings gear is the second item
       return actions.getChildAt(1);

--- a/src/main/java/com/pyamsoft/padlock/app/main/MainActivity.java
+++ b/src/main/java/com/pyamsoft/padlock/app/main/MainActivity.java
@@ -108,11 +108,9 @@ public class MainActivity extends RatingActivity implements MainPresenter.MainVi
   @Override protected void onPause() {
     super.onPause();
     if (isFinishing() || isChangingConfigurations()) {
-      final View amv = binding.toolbar.getChildAt(1);
-      if (amv instanceof ActionMenuView) {
-        final ActionMenuView actions = (ActionMenuView) amv;
-        actions.dismissPopupMenus();
-      }
+      Timber.d("Even though a leak is reported, this should dismiss the window, and clear the leak");
+      binding.toolbar.getMenu().close();
+      binding.toolbar.dismissPopupMenus();
     }
   }
 


### PR DESCRIPTION
Bandaids the popupmenu leak a bit better using toolbar methods to actually dismiss the window.

It will still report as leak, but should be freed up so it won't "actually" leak